### PR TITLE
Add traceback message level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ pytest tests --tr-reporting
 | --tr-deselect-tests | If pass testrun id only. Selects only tests which have been marked with case decorator with appropriate case id. Other tests are marked as deselected and not started in test execution. |
 
 ### All available pytest.ini options.
-| option           | description                                                                           |
-|------------------|---------------------------------------------------------------------------------------|
-| tr_api_url       | Testrail api url.                                                                     |
-| tr_run_id        | Testrail test run id. If passed test reports are linked to this particular test run.  |
-| tr_user_email    | Testrail User email for API authentication.                                           |
-| tr_user_password | Testrail User password for API authentication.                                        |
-| tr_project_id    | Testrail Project Id. Required for new test run creation if Test Run Id is not passed. |
-| tr_suite_id      | Testrail Suite Id. Required for new test run creation if Test Run Id is not passed.   |
+| option           | description                                                                                           |
+|------------------|-------------------------------------------------------------------------------------------------------|
+| tr_api_url       | Testrail api url.                                                                                     |
+| tr_run_id        | Testrail test run id. If passed test reports are linked to this particular test run.                  |
+| tr_user_email    | Testrail User email for API authentication.                                                           |
+| tr_user_password | Testrail User password for API authentication.                                                        |
+| tr_project_id    | Testrail Project Id. Required for new test run creation if Test Run Id is not passed.                 |
+| tr_suite_id      | Testrail Suite Id. Required for new test run creation if Test Run Id is not passed.                   |
+| tr_tb            | Traceback level in testrail message reports. ['short', 'long'] options. Short is selected by default. |
 
 
 ### Hooks

--- a/pytest_testrail_integrator/client.py
+++ b/pytest_testrail_integrator/client.py
@@ -4,12 +4,7 @@ from typing import List, Union
 
 import pydash
 import pytest
-from _pytest.config import ExitCode, Config
-from _pytest.main import Session
-from _pytest.mark import Mark
-from _pytest.nodes import Item
-from _pytest.reports import TestReport
-from _pytest.runner import CallInfo
+from pytest import ExitCode, Config, Session, Mark, Item, TestReport, CallInfo
 
 from .config import TrConfig
 from .constants import TR_MARKER_NAME, TR_PASSED_TESTS_FLUSH_SIZE, TestrailStatus, \

--- a/pytest_testrail_integrator/config.py
+++ b/pytest_testrail_integrator/config.py
@@ -1,6 +1,6 @@
 import os
 
-from _pytest.config import Config
+from pytest import Config
 
 from pytest_testrail_integrator.constants import TestrailMsgStyle
 

--- a/pytest_testrail_integrator/config.py
+++ b/pytest_testrail_integrator/config.py
@@ -2,6 +2,8 @@ import os
 
 from _pytest.config import Config
 
+from pytest_testrail_integrator.constants import TestrailMsgStyle
+
 
 class TrConfig:
     def __init__(self, config: Config):
@@ -14,6 +16,7 @@ class TrConfig:
         self.user_password = os.getenv('TR_USER_PASSWORD') or config.getini('tr_user_password')
         self.project_id = os.getenv('TR_PROJECT_ID') or config.getini('tr_project_id')
         self.suite_id = os.getenv('TR_SUITE_ID') or config.getini('tr_suite_id')
+        self.tb_style = TestrailMsgStyle(config.getoption('--tr-tb') or config.getini('tr_tb') or 'short')
 
         required_keys = (self.api_url, self.user_email, self.user_password)
         assert all(required_keys)

--- a/pytest_testrail_integrator/constants.py
+++ b/pytest_testrail_integrator/constants.py
@@ -31,3 +31,8 @@ PYTEST_TO_TESTRAIL_STATUS = {
     PytestStatus.FAILED: TestrailStatus.FAILED,
     PytestStatus.SKIPPED: TestrailStatus.SKIP
 }
+
+
+class TestrailMsgStyle(enum.Enum):
+    LONG = 'long'
+    SHORT = 'short'

--- a/pytest_testrail_integrator/dto.py
+++ b/pytest_testrail_integrator/dto.py
@@ -1,9 +1,8 @@
 import dataclasses
 from typing import List, Union, Tuple
 
-from _pytest._code import ExceptionInfo
 from _pytest._code.code import TerminalRepr
-from _pytest.mark import Mark
+from pytest import ExceptionInfo, Mark
 
 from pytest_testrail_integrator.constants import PytestStatus
 

--- a/pytest_testrail_integrator/plugin.py
+++ b/pytest_testrail_integrator/plugin.py
@@ -1,6 +1,5 @@
 import pytest
-from _pytest.config import PytestPluginManager
-from _pytest.config.argparsing import Parser
+from pytest import PytestPluginManager, Parser
 from testrail_api import TestRailAPI
 
 from pytest_testrail_integrator.client import TrClient

--- a/pytest_testrail_integrator/plugin.py
+++ b/pytest_testrail_integrator/plugin.py
@@ -23,9 +23,6 @@ def pytest_addoption(parser: Parser):
     group.addoption(
         '--tr-tb',
         action='store',
-        type=str,
-        const='short',
-        nargs='?',
         help='Sets traceback level in testrail message reports.'
     )
     parser.addini('tr_url', default='', help='Testrail Api url.')

--- a/pytest_testrail_integrator/plugin.py
+++ b/pytest_testrail_integrator/plugin.py
@@ -4,8 +4,8 @@ from _pytest.config.argparsing import Parser
 from testrail_api import TestRailAPI
 
 from pytest_testrail_integrator.client import TrClient
-from pytest_testrail_integrator.service import TrService
 from pytest_testrail_integrator.config import TrConfig
+from pytest_testrail_integrator.service import TrService
 
 
 def pytest_addoption(parser: Parser):
@@ -20,12 +20,21 @@ def pytest_addoption(parser: Parser):
         action='store_true',
         help='Deselect tests if its\' case is not present in run.'
     )
+    group.addoption(
+        '--tr-tb',
+        action='store',
+        type=str,
+        const='short',
+        nargs='?',
+        help='Sets traceback level in testrail message reports.'
+    )
     parser.addini('tr_url', default='', help='Testrail Api url.')
     parser.addini('tr_user_email', default='', help='Testrail user\'s email.')
     parser.addini('tr_user_password', default='', help='Testrail user\'s password.')
     parser.addini('tr_project_id', default='', help='Testrail project id for new testrun creation.')
     parser.addini('tr_suite_id', default='', help='Testrail suite id to create test run from.')
     parser.addini('tr_run_id', default='', help='Testrail run id to update tests in.')
+    parser.addini('tr_tb', default='', help='Sets traceback level in testrail message reports.')
 
 
 @pytest.hookimpl

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,8 @@ class TestClient:
         config = pytester.parseconfig()
         options = {
             "--tr-reporting": True,
-            "--tr-deselect-tests": deselect_flag
+            "--tr-deselect-tests": deselect_flag,
+            "--tr-tb": 'short'
         }
 
         config.getoption = lambda x, y=None: options[x] or y

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pytest_testrail_integrator.config import TrConfig
+from pytest_testrail_integrator.constants import TestrailMsgStyle
 
 INI = {
     'tr_run_id': '2',
@@ -8,7 +9,8 @@ INI = {
     'tr_user_email': 'user@example.com',
     'tr_user_password': 'asdf',
     'tr_project_id': '54',
-    'tr_suite_id': '11'
+    'tr_suite_id': '11',
+    'tr_tb': 'long'
 }
 
 
@@ -16,7 +18,8 @@ def test_config_env_var_has_grater_priority(pytester: pytest.Pytester, setup_env
     config = pytester.parseconfig()
     options = {
         "--tr-reporting": True,
-        "--tr-deselect-tests": False
+        "--tr-deselect-tests": False,
+        "--tr-tb": "long"
     }
 
     config.getoption = lambda x, y=None: options[x] or y
@@ -28,13 +31,15 @@ def test_config_env_var_has_grater_priority(pytester: pytest.Pytester, setup_env
     assert tr_config.user_password == 'qwerty'
     assert tr_config.project_id == '321'
     assert tr_config.suite_id == '1122'
+    assert tr_config.tb_style == TestrailMsgStyle.LONG
 
 
 def test_config_env_loads_from_ini(pytester: pytest.Pytester):
     config = pytester.parseconfig()
     options = {
         "--tr-reporting": False,
-        "--tr-deselect-tests": True
+        "--tr-deselect-tests": True,
+        '--tr-tb': ''
     }
 
     config.getoption = lambda x, y=None: options[x] or y
@@ -46,13 +51,15 @@ def test_config_env_loads_from_ini(pytester: pytest.Pytester):
     assert tr_config.user_password == 'asdf'
     assert tr_config.project_id == '54'
     assert tr_config.suite_id == '11'
+    assert tr_config.tb_style == TestrailMsgStyle.LONG
 
 
-def test_trconfig_requiered_keys_missed(pytester: pytest.Pytester):
+def test_trconfig_required_keys_missed(pytester: pytest.Pytester):
     config = pytester.parseconfig()
     options = {
         "--tr-reporting": False,
-        "--tr-deselect-tests": True
+        "--tr-deselect-tests": True,
+        "--tr-tb": ''
     }
 
     config.getini = lambda x: ''


### PR DESCRIPTION
Added optional flags `--tr-tb` to command line and `tr_tb` to `pytest.ini` file.
**Supported options:** `long` and `short`.
**Load priority:** command line -> `pytest.ini` -> default value `short`.

If `short` is selected only first part of error message will be taken(all before `+ where` str.)

resolves #3 